### PR TITLE
Added "middle click toggles pause" behaviour

### DIFF
--- a/tray_icon.py
+++ b/tray_icon.py
@@ -20,7 +20,9 @@ class TrayIcon(GObject.Object, Peas.Activatable):
 			else:
 				self.wind.show()
 				self.wind.present()
-
+		elif event.button == 2: # middle button
+			self.player.playpause(True)	
+			
 	def play(self, widget):
 		self.player.playpause(True) # does nothing argument
 


### PR DESCRIPTION
I've replicated the old tray icon behaviour where a middle click on the icon causes Rhythmbox to toggle pause.
